### PR TITLE
feat: add nix flake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 output*
 build/
+/result
+/result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788881743,
+        "narHash": "sha256-2V9GZGvPfrNzxFozhI9dcqV+c3QdA8YZrvAAzqEB+dI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d6524aaca2ff07876657ae2b323f24be4874944b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "OpenFlux - Universal Bypass Tool";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      pkgs = forAllSystems (system: nixpkgs.legacyPackages.${system});
+    in {
+      packages = forAllSystems (system: rec {
+        openflux = pkgs.${system}.callPackage ./nix/package.nix {
+          inherit self;
+        };
+        default = openflux;
+      });
+
+      devShells = forAllSystems (system: {
+        default = pkgs.${system}.callPackage ./nix/shell.nix { };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,17 @@
   description = "OpenFlux - Universal Bypass Tool";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
-      systems = [ "x86_64-linux" "aarch64-linux" ];
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
       pkgs = forAllSystems (system: nixpkgs.legacyPackages.${system});
-    in {
+    in
+    {
       packages = forAllSystems (system: rec {
         openflux = pkgs.${system}.callPackage ./nix/package.nix {
           inherit self;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -10,4 +10,6 @@
   src = self;
   vendorHash = "sha256-MITicQOVM8O22ZS2iO5Lx9pIqtXNTQ2MBzan4Q1PjDI=";
   ldflags = [ "-s" "-w" ];
+
+  meta.mainProgram = "universal-bypass-tool";
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -6,7 +6,7 @@
 }:
 (buildGoModule.override { go = go_1_26; }) {
   pname = "openflux";
-  version = "0.1.0";
+  version = self.shortRev;
   src = self;
   vendorHash = "sha256-MITicQOVM8O22ZS2iO5Lx9pIqtXNTQ2MBzan4Q1PjDI=";
   ldflags = [

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,13 @@
+{
+  lib,
+  buildGoModule,
+  go_1_26,
+  self,
+}:
+(buildGoModule.override { go = go_1_26; }) {
+  pname = "openflux";
+  version = "0.1.0";
+  src = self;
+  vendorHash = "sha256-MITicQOVM8O22ZS2iO5Lx9pIqtXNTQ2MBzan4Q1PjDI=";
+  ldflags = [ "-s" "-w" ];
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -9,7 +9,10 @@
   version = "0.1.0";
   src = self;
   vendorHash = "sha256-MITicQOVM8O22ZS2iO5Lx9pIqtXNTQ2MBzan4Q1PjDI=";
-  ldflags = [ "-s" "-w" ];
+  ldflags = [
+    "-s"
+    "-w"
+  ];
 
   meta.mainProgram = "universal-bypass-tool";
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -6,5 +6,10 @@
   nixfmt,
 }:
 mkShell {
-  packages = [ go_1_26 gopls delve nixfmt ];
+  packages = [
+    go_1_26
+    gopls
+    delve
+    nixfmt
+  ];
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,10 @@
+{
+  mkShell,
+  go_1_26,
+  gopls,
+  delve,
+  nixfmt,
+}:
+mkShell {
+  packages = [ go_1_26 gopls delve nixfmt ];
+}


### PR DESCRIPTION
## What's added
- `nix run`, `nix shell`, `nix build`, etc. support 
### Examples
```bash
# won't work until this PR merged
# to test right now use 'nix run github:keepinfov/openflux/feat/add-nix-flake-support'
nix run github:p1neappleXpress/openflux
```
```bash
nix shell github:p1neappleXpress/openflux
```
or for local build fe:
```bash
nix build .
```