### PR TITLE
fix(docs): added russian docs, moved XCODE_PATH to env variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 output*
 build/
+.idea

--- a/README.md
+++ b/README.md
@@ -1,14 +1,27 @@
 # OpenFlux - Universal Bypass Tool
 
+**English** | [Русский](README.ru.md)
+
 Network stack research tool. TCP tunnel with pluggable transports.
 
+## Overview
 ```
 Client (SOCKS5) --> Transport --> Exit Node --> Internet
 ```
 
-## What it does
+## Requirements
+1. Golang v. 1.26.3+ - is required for building desktop client / exit node binary (universal-bypass-tool);
+2. Android Native Development Kit (NDK) v.27.0.12077973+ - is required for building Android client binary;
+3. XCode v. 26.6+ - is required for building iOS client binary;
+4. Linux VPS / VDS exit node.
 
-Sends TCP packets through Yandex Docs cursor messages (or webRTC datachannel if MAX transport selected). Client side runs a SOCKS5 proxy, exit node decapsulates and forwards to real internet.
+## Overview
+
+TCP packets are sent via Transport. Currently, there are two transports available:
+1. Yandex - sends packets via Yandex Docs cursor messages;
+2. Max - sends packets via WebRTC DataChannel.
+
+Client side runs a SOCKS5 proxy, exit node decapsulates and forwards packets to destination point.
 
 ## Structure
 
@@ -28,60 +41,62 @@ universal-bypass-tool/
 └── utils/                # Debug logging
 ```
 
-## Build
+## Build (desktop client / exit-node binary)
 
 ```bash
 go mod tidy
 go build -o universal-bypass-tool .
 ```
 
-## Build for Android
+## Build for Android (client binary)
 ```bash
-export ANDROID_NDK_HOME=<YOUR ANDROID NDK PATH>
+export ANDROID_NDK_HOME=<your Android NDK path>
 ./build_android.sh
 ```
 
-## Build for iOS
+## Build for iOS (client binary)
 ```bash
-XCODE_PATH="/Applications/Xcode.app"  # or Xcode-beta path
-SDK_PATH="$XCODE_PATH/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
+export XCODE_PATH="<your Xcode.app path>" # optional, defaults to /Applications/Xcode.app
 ./build_ios.sh
 ```
 
 ## Usage
 
-Exit node (needs root):
+### 1. Setting up exit node
+1. You must have root access on exit node machine;
+2. Only legacy Yandex document editor is supported (you can toggle this setting from the interface).
 
-Please use the old document editor. At the moment, the application crashes if you use the new one. I will fix this problem as soon as possible.
-
+Setup commands for exit node:
 ```bash
 sudo iptables -A OUTPUT -p tcp --tcp-flags RST RST -j DROP
 sudo ./universal-bypass-tool --exit-node --url "YOUR_YANDEX_DOC_URL" --debug
 ```
 
-Client:
+### 1. Setting up desktop client:
+
+Setup commands for desktop client:
 ```bash
 ./universal-bypass-tool --client --url "YOUR_YANDEX_DOC_URL" --socks5 :1080 --debug
 ```
 
-Then point your browser to SOCKS5 proxy at localhost:1080.
+Then set up SOCKS5 proxy in your browser at localhost:1080.
 
 ## Flags
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--client` | | Run as client |
-| `--exit-node` | | Run as exit node |
-| `--socks5` | `:1080` | SOCKS5 listen addr |
-| `--url` | `https://localhost` | Document URL (Yandex Docs) |
-| `--maxToken` | `` | Token (Max) |
-| `--maxUid` | `` | User ID (Max) |
-| `--debug` | `false` | Verbose logging |
-| `--transport` | `yandex` | Transport backend |
+| Flag          | Default             | Description                |
+|---------------|---------------------|----------------------------|
+| `--client`    |                     | Run as client              |
+| `--exit-node` |                     | Run as exit node           |
+| `--socks5`    | `:1080`             | SOCKS5 listen address      |
+| `--url`       | `https://localhost` | Document URL (Yandex Docs) |
+| `--maxToken`  | ``                  | Auth token (Max)           |
+| `--maxUid`    | ``                  | User ID (Max)              |
+| `--debug`     | `false`             | Enable verbose logging     |
+| `--transport` | `yandex`            | Select transport backend   |
 
-## Adding new transports
+## Implementing custom transports
 
-Implement the `Transport` interface from `transport/transport.go`, add your package, register in main.go switch.
+You are free to implement the `Transport` interface from `transport/transport.go` and register your custom transport in main.go switch block.
 
 ## License
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,103 @@
+# OpenFlux - Universal Bypass Tool
+
+[English](README.md) | **Русский**
+
+Исследовательский инструмент сетевого стека. TCP-туннель с подключаемыми транспортами.
+
+## Обзор
+```
+Client (SOCKS5) --> Transport --> Exit Node --> Internet
+```
+
+## Требования
+1. Golang v. 1.26.3+ — требуется для сборки бинарника десктопного клиента / выходной ноды (universal-bypass-tool);
+2. Android Native Development Kit (NDK) v.27.0.12077973+ — требуется для сборки бинарника для Android-клиента;
+3. XCode v. 26.6+ — требуется для сборки бинарника для iOS-клиента;
+4. VPS / VDS выходная нода на Linux.
+
+## Обзор
+
+TCP-пакеты передаются через Transport. На данный момент доступны два транспорта:
+1. Yandex — отправляет пакеты через курсорные сообщения Yandex Docs;
+2. Max — отправляет пакеты через WebRTC DataChannel.
+
+Клиентская часть запускает SOCKS5-прокси, выходная нода декапсулирует и пересылает пакеты в пункт назначения.
+
+## Структура
+
+```
+universal-bypass-tool/
+├── main.go
+├── transport/
+│   ├── transport.go      # Transport interface
+│   └── yandex/           # Yandex Docs backend
+│   └── oneme/            # MAX Messenger backend
+├── tunnel/
+│   ├── tunnel.go         # TCP tunnel core
+│   ├── endpoint.go       # Virtual NIC
+│   └── rawsocket.go      # Raw socket (exit node)
+├── socks5/               # SOCKS5 server
+├── network/              # Checksums, packet parsing
+└── utils/                # Debug logging
+```
+
+## Сборка (бинарник десктоп-клиента / выходной ноды)
+
+```bash
+go mod tidy
+go build -o universal-bypass-tool .
+```
+
+## Сборка для Android (клиентский бинарник)
+```bash
+export ANDROID_NDK_HOME=<путь до вашего Android NDK>
+./build_android.sh
+```
+
+## Сборка для iOS (клиентский бинарник)
+```bash
+export XCODE_PATH="<путь до вашего Xcode.app>" # опционально, по умолчанию /Applications/Xcode.app
+./build_ios.sh
+```
+
+## Использование
+
+### 1. Настройка выходной ноды
+1. У вас должен быть root-доступ выходной ноде;
+2. Поддерживается только устаревший редактор документов Yandex (переключается в настройках интерфейса).
+
+Команды для настройки выходной ноды:
+```bash
+sudo iptables -A OUTPUT -p tcp --tcp-flags RST RST -j DROP
+sudo ./universal-bypass-tool --exit-node --url "YOUR_YANDEX_DOC_URL" --debug
+```
+
+### 1. Настройка десктопного клиента:
+
+Команды для настройки десктопного клиента:
+```bash
+./universal-bypass-tool --client --url "YOUR_YANDEX_DOC_URL" --socks5 :1080 --debug
+```
+
+Затем настройте SOCKS5-прокси в браузере на localhost:1080.
+
+## Флаги
+
+| Флаг          | По умолчанию        | Описание                       |
+|---------------|---------------------|--------------------------------|
+| `--client`    |                     | Запуск в режиме клиента        |
+| `--exit-node` |                     | Запуск в режиме ноды           |
+| `--socks5`    | `:1080`             | Адрес SOCKS5 прокси            |
+| `--url`       | `https://localhost` | URL документа (Yandex Docs)    |
+| `--maxToken`  | ``                  | Токен авторизации (Max)        |
+| `--maxUid`    | ``                  | ID пользователя (Max)          |
+| `--debug`     | `false`             | Включить подробное логирование |
+| `--transport` | `yandex`            | Выбор транспорта               |
+
+## Реализация собственных транспортов
+
+Вы можете реализовать интерфейс `Transport` из `transport/transport.go` и зарегистрировать свой транспорт в switch-блоке в main.go.
+
+## Лицензия
+
+Только для образовательных целей. Тестируйте на собственных машинах и сетях.

--- a/build_android.sh
+++ b/build_android.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-#ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-$HOME/Android/Sdk/ndk/27.0.12077973}"
+ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-$HOME/Android/Sdk/ndk/27.0.12077973}"
 OUTPUT_DIR="output/android/arm64-v8a"
 BINARY_NAME="openflux"
 

--- a/build_ios.sh
+++ b/build_ios.sh
@@ -5,7 +5,7 @@ OUTPUT_DIR="output/ios"
 LIBRARY_NAME="liboflux"
 
 # Paths configuration
-XCODE_PATH="/path/to/Xcode.app"
+XCODE_PATH="${XCODE_PATH:-/Applications/Xcode.app}"
 DEVELOPER_DIR="$XCODE_PATH/Contents/Developer"
 SDK_PATH="$DEVELOPER_DIR/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
 CLANG="$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"


### PR DESCRIPTION
1. Added backend and client binary build requirements to the docs;
2. Added Russian translation of the docs;
3. Moved `XCODE_PATH` to an environment variable, aligning it with the Android build script.

----

1. Добавил в документацию требования для сборки бэкенда и клиентских бинарников;
2. Добавил русский перевод для доки;
3. Перенес `XCODE_PATH` в переменную окружения по аналогии со скриптом сборки для Android.