### PR TITLE
main: fix swapped maxToken/maxUid flag descriptions

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,8 +31,8 @@ func main() {
 	socksAddr := flag.String("socks5", ":1080", "SOCKS5 address")
 	transportType := flag.String("transport", "yandex", "Transport type (yandex, google, custom)")
 	flag.StringVar(&globalDocUrl, "url", "http://#", "Document URL. If u use Yandex.Docs transport")
-	flag.StringVar(&maxToken, "maxToken", "", "MAX call user id. If u use MAX transport")
-	flag.StringVar(&maxUid, "maxUid", "", "MAX Web token. If u use MAX transport")
+	flag.StringVar(&maxToken, "maxToken", "", "MAX Web token. If u use MAX transport")
+	flag.StringVar(&maxUid, "maxUid", "", "MAX call user id. If u use MAX transport")
 	flag.Parse()
 
 	if !*exitNode && !*client {


### PR DESCRIPTION
`-help` describes `-maxToken` as "MAX call user id" and `-maxUid` as "MAX Web token". Both are the wrong way round:

- the README flags table lists `--maxToken` as "Auth token (Max)" and `--maxUid` as "User ID (Max)";
- `main.go` passes `maxToken` to `LoginByToken` and `maxUid` to `startOutgoingCall` as the callee id, so the code already treats the token as the token and the uid as the uid.

A user setting up the MAX transport from `-help` therefore passes each value in the wrong slot. This swaps the two description strings only; no behaviour change.

Verified by running `--help` before and after, plus `go build ./...` and `go vet ./...`.