### PR TITLE
Добавить опциональное сквозное шифрование транспорта AES-256-GCM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/pion/webrtc/v3 v3.3.6
 	github.com/wlynxg/anet v0.0.5
+	golang.org/x/crypto v0.51.0
 )
 
 require (
@@ -41,7 +42,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/xjasonlyu/windivert-go v0.0.0-20201010013527-4239d0afa76f // indirect
-	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	godebug "runtime/debug"
 	"strconv"
+	"strings"
         _ "github.com/wlynxg/anet"
 	"universal-bypass-tool/socks5"
 	"universal-bypass-tool/transport"
@@ -20,7 +21,7 @@ var (
 	globalDocUrl string
 	maxToken     string
 	maxUid       string
-	localIP      string 
+	localIP      string
 )
 
 func main() {
@@ -36,6 +37,9 @@ func main() {
 	flag.StringVar(&maxToken, "maxToken", "", "MAX Web token. If u use MAX transport")
 	flag.StringVar(&maxUid, "maxUid", "", "MAX call user id. If u use MAX transport")
 	flag.StringVar(&localIP, "local-ip", "", "Egress IP for exit node (scoped RST drop)")
+	encryptionKeyFile := flag.String("encryption-key-file", "",
+		"Optional: encrypt the transport with AES-256-GCM using a shared secret read from this file. "+
+			"Both peers must use the same secret; unset means unencrypted, unchanged behavior")
 	flag.Parse()
 
 	if localIP != "" {
@@ -62,19 +66,41 @@ func main() {
 	log.Printf("Transport: %s", *transportType)
 
 	config := transport.DefaultConfig()
-	var trans transport.Transport
+	var inner transport.Transport
 
 	switch *transportType {
 	case "vyandex":
-		trans = transport.NewCompressedTransport(yandex.NewYandexVolgaTransport(globalDocUrl, config))
+		inner = yandex.NewYandexVolgaTransport(globalDocUrl, config)
 	case "yandex":
-		trans = transport.NewCompressedTransport(yandex.NewYandexDocsTransport(globalDocUrl, config))
+		inner = yandex.NewYandexDocsTransport(globalDocUrl, config)
 	case "oneme":
 		uidint, _ := strconv.ParseInt(maxUid, 10, 64)
-		trans = transport.NewCompressedTransport(oneme.NewOneMeTransport(*exitNode, maxToken, uidint, config))
+		inner = oneme.NewOneMeTransport(*exitNode, maxToken, uidint, config)
 	default:
 		log.Fatalf("Unknown transport type: %s", *transportType)
 	}
+
+	if *encryptionKeyFile != "" {
+		secretBytes, err := os.ReadFile(*encryptionKeyFile)
+		if err != nil {
+			log.Fatalf("Read encryption key file: %v", err)
+		}
+		// The context is just a public KDF salt (domain separation between
+		// unrelated sessions using the same secret), not a secret itself -
+		// the document URL is a convenient, already-shared identifier.
+		context := *transportType
+		if globalDocUrl != "" {
+			context = globalDocUrl
+		}
+		encrypted, err := transport.NewEncryptedTransport(inner, strings.TrimSpace(string(secretBytes)), context, *exitNode)
+		if err != nil {
+			log.Fatalf("Configure encrypted transport: %v", err)
+		}
+		inner = encrypted
+		log.Printf("Transport encryption: AES-256-GCM enabled")
+	}
+
+	trans := transport.NewCompressedTransport(inner)
 
 	if err := trans.Start(); err != nil {
 		log.Fatalf("Failed to start transport: %v", err)

--- a/transport/encrypted.go
+++ b/transport/encrypted.go
@@ -1,0 +1,157 @@
+package transport
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sync"
+
+	"golang.org/x/crypto/scrypt"
+)
+
+const (
+	encryptedVersion = byte(1)
+	encryptedHeader  = 5
+	maxSeenNonces    = 4096
+)
+
+var encryptedMagic = [3]byte{'O', 'F', 'X'}
+
+// EncryptedTransport wraps another Transport with end-to-end AES-256-GCM
+// authenticated encryption, so the transport's own provider only ever
+// observes ciphertext. Keys are derived from a shared secret via scrypt; the
+// context string is just a public, per-session KDF salt - secrecy comes
+// exclusively from the secret, which both peers must share out of band.
+//
+// Each direction (client->exit, exit->client) uses its own derived key, so a
+// compromise of one direction's traffic does not help decrypt the other.
+// Every packet also carries a random nonce and is checked against a bounded
+// replay window, so a captured packet cannot be replayed back at either
+// peer.
+type EncryptedTransport struct {
+	Transport
+	sendAEAD      cipher.AEAD
+	receiveAEAD   cipher.AEAD
+	sendDirection byte
+	recvDirection byte
+	seenMu        sync.Mutex
+	seen          map[string]struct{}
+	seenOrder     []string
+}
+
+// NewEncryptedTransport wraps inner with a directional AES-256-GCM stream.
+// Both peers must be configured with the same secret and context, and
+// exactly one of them must set exitNode=true so the two sides pick opposite
+// send/receive key pairs.
+func NewEncryptedTransport(inner Transport, secret, context string, exitNode bool) (*EncryptedTransport, error) {
+	if inner == nil {
+		return nil, errors.New("inner transport is nil")
+	}
+	if len(secret) < 16 {
+		return nil, errors.New("encryption secret must contain at least 16 characters")
+	}
+
+	salt := sha256.Sum256([]byte("OpenFlux encrypted transport v1\x00" + context))
+	master, err := scrypt.Key([]byte(secret), salt[:], 32768, 8, 1, 32)
+	if err != nil {
+		return nil, fmt.Errorf("derive encryption key: %w", err)
+	}
+	clientToExit := deriveDirectionalKey(master, "client-to-exit")
+	exitToClient := deriveDirectionalKey(master, "exit-to-client")
+
+	sendKey, receiveKey := clientToExit, exitToClient
+	sendDirection, receiveDirection := byte(0), byte(1)
+	if exitNode {
+		sendKey, receiveKey = exitToClient, clientToExit
+		sendDirection, receiveDirection = 1, 0
+	}
+	sendAEAD, err := newGCM(sendKey)
+	if err != nil {
+		return nil, err
+	}
+	receiveAEAD, err := newGCM(receiveKey)
+	if err != nil {
+		return nil, err
+	}
+	return &EncryptedTransport{
+		Transport:     inner,
+		sendAEAD:      sendAEAD,
+		receiveAEAD:   receiveAEAD,
+		sendDirection: sendDirection,
+		recvDirection: receiveDirection,
+		seen:          make(map[string]struct{}),
+	}, nil
+}
+
+func deriveDirectionalKey(master []byte, label string) []byte {
+	mac := hmac.New(sha256.New, master)
+	_, _ = mac.Write([]byte("OpenFlux direction v1\x00" + label))
+	return mac.Sum(nil)
+}
+
+func newGCM(key []byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("create AES cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create AES-GCM: %w", err)
+	}
+	return aead, nil
+}
+
+func (e *EncryptedTransport) Send(data []byte) error {
+	header := []byte{encryptedMagic[0], encryptedMagic[1], encryptedMagic[2], encryptedVersion, e.sendDirection}
+	nonce := make([]byte, e.sendAEAD.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return fmt.Errorf("create packet nonce: %w", err)
+	}
+	packet := make([]byte, 0, len(header)+len(nonce)+len(data)+e.sendAEAD.Overhead())
+	packet = append(packet, header...)
+	packet = append(packet, nonce...)
+	packet = e.sendAEAD.Seal(packet, nonce, data, header)
+	return e.Transport.Send(packet)
+}
+
+func (e *EncryptedTransport) Receive(callback func([]byte)) {
+	e.Transport.Receive(func(packet []byte) {
+		if len(packet) < encryptedHeader+e.receiveAEAD.NonceSize()+e.receiveAEAD.Overhead() {
+			return
+		}
+		header := packet[:encryptedHeader]
+		if header[0] != encryptedMagic[0] || header[1] != encryptedMagic[1] ||
+			header[2] != encryptedMagic[2] || header[3] != encryptedVersion ||
+			header[4] != e.recvDirection {
+			return
+		}
+		nonceEnd := encryptedHeader + e.receiveAEAD.NonceSize()
+		nonce := packet[encryptedHeader:nonceEnd]
+		plaintext, err := e.receiveAEAD.Open(nil, nonce, packet[nonceEnd:], header)
+		if err != nil || !e.rememberNonce(nonce) {
+			return
+		}
+		callback(plaintext)
+	})
+}
+
+func (e *EncryptedTransport) rememberNonce(nonce []byte) bool {
+	key := string(nonce)
+	e.seenMu.Lock()
+	defer e.seenMu.Unlock()
+	if _, exists := e.seen[key]; exists {
+		return false
+	}
+	e.seen[key] = struct{}{}
+	e.seenOrder = append(e.seenOrder, key)
+	if len(e.seenOrder) > maxSeenNonces {
+		oldest := e.seenOrder[0]
+		e.seenOrder = e.seenOrder[1:]
+		delete(e.seen, oldest)
+	}
+	return true
+}

--- a/transport/encrypted_test.go
+++ b/transport/encrypted_test.go
@@ -1,0 +1,108 @@
+package transport
+
+import (
+	"bytes"
+	"testing"
+)
+
+type testTransport struct {
+	receiver func([]byte)
+	sent     []byte
+}
+
+func (t *testTransport) Start() error                  { return nil }
+func (t *testTransport) Stop() error                   { return nil }
+func (t *testTransport) IsConnected() bool             { return true }
+func (t *testTransport) Stats() TransportStats         { return TransportStats{} }
+func (t *testTransport) Receive(callback func([]byte)) { t.receiver = callback }
+func (t *testTransport) Send(data []byte) error        { t.sent = append([]byte(nil), data...); return nil }
+func (t *testTransport) deliver(data []byte) {
+	if t.receiver != nil {
+		t.receiver(data)
+	}
+}
+
+func TestEncryptedTransportRoundTrip(t *testing.T) {
+	clientWire := &testTransport{}
+	exitWire := &testTransport{}
+	client, err := NewEncryptedTransport(clientWire, "a sufficiently long shared secret", "document", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exitNode, err := NewEncryptedTransport(exitWire, "a sufficiently long shared secret", "document", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []byte("private IPv4 packet")
+	var got []byte
+	exitNode.Receive(func(data []byte) { got = append([]byte(nil), data...) })
+	if err := client.Send(want); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(clientWire.sent, want) {
+		t.Fatal("ciphertext contains plaintext")
+	}
+	exitWire.deliver(clientWire.sent)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("received %q, want %q", got, want)
+	}
+
+	reply := []byte("private response")
+	got = nil
+	client.Receive(func(data []byte) { got = append([]byte(nil), data...) })
+	if err := exitNode.Send(reply); err != nil {
+		t.Fatal(err)
+	}
+	clientWire.deliver(exitWire.sent)
+	if !bytes.Equal(got, reply) {
+		t.Fatalf("received %q, want %q", got, reply)
+	}
+}
+
+func TestEncryptedTransportRejectsWrongKeyTamperingAndReplay(t *testing.T) {
+	wire := &testTransport{}
+	client, err := NewEncryptedTransport(wire, "first sufficiently long secret", "document", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Send([]byte("packet")); err != nil {
+		t.Fatal(err)
+	}
+
+	wrongWire := &testTransport{}
+	wrongExit, err := NewEncryptedTransport(wrongWire, "other sufficiently long secret", "document", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	called := 0
+	wrongExit.Receive(func([]byte) { called++ })
+	wrongWire.deliver(wire.sent)
+	if called != 0 {
+		t.Fatal("wrong key was accepted")
+	}
+
+	rightWire := &testTransport{}
+	rightExit, err := NewEncryptedTransport(rightWire, "first sufficiently long secret", "document", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightExit.Receive(func([]byte) { called++ })
+	tampered := append([]byte(nil), wire.sent...)
+	tampered[len(tampered)-1] ^= 1
+	rightWire.deliver(tampered)
+	if called != 0 {
+		t.Fatal("tampered packet was accepted")
+	}
+	rightWire.deliver(wire.sent)
+	rightWire.deliver(wire.sent)
+	if called != 1 {
+		t.Fatalf("replayed packet delivered %d times, want 1", called)
+	}
+}
+
+func TestEncryptedTransportRequiresStrongSecret(t *testing.T) {
+	if _, err := NewEncryptedTransport(&testTransport{}, "too short", "document", false); err == nil {
+		t.Fatal("short secret was accepted")
+	}
+}


### PR DESCRIPTION
## Суть
- Добавляет обёртку `EncryptedTransport` (`transport/encrypted.go`), которая шифрует трафик любого `Transport` сквозным AES-256-GCM.
- Направленные ключи выводятся из общего секрета через scrypt - компрометация ключа client->exit не помогает расшифровать трафик exit->client, и наоборот.
- Каждый пакет несёт случайный nonce и проверяется по ограниченному окну защиты от replay-атак.
- Полностью опционально, через новый флаг `--encryption-key-file`: если флаг не указан, поведение не меняется ни на байт. Если указан - оборачивает выбранный транспорт (`yandex`, `vyandex`, `oneme`) перед сжатием, так что владелец документа (или кто угодно ещё, кто ретранслирует трафик) видит только шифротекст.
- Оба пира (клиент и exit-node) должны быть запущены с одним и тем же файлом секрета; строка контекста, используемая как соль для KDF, - это публичное значение для разделения доменов, а не секрет.

## Зачем
Сейчас конфиденциальность трафика полностью зависит от того, что предоставляет сам транспорт. Это добавляет независимый от транспорта опциональный слой шифрования - пользователи, которым это нужно, получают сквозную конфиденциальность независимо от выбранного бэкенда, не затрагивая существующие развёртывания, где новый флаг не используется.

## План тестирования
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./transport/...` (новые тесты: round-trip, отклонение неверного ключа/подмены/replay, отказ на слабый секрет)
- [ ] ручной smoke-тест клиент/exit-node с `--encryption-key-file` на обеих сторонах
