### PR TITLE
Транспорт: батчинг + zstd — меньше сообщений в канале Yandex, выше скорость

### DIFF
--- a/bench.go
+++ b/bench.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	mrand "math/rand"
+	"sync/atomic"
+	"time"
+
+	"universal-bypass-tool/transport"
+)
+
+// A distinct end-of-stream marker the sink recognizes. 41 bytes; a random
+// payload matching it is astronomically unlikely.
+var benchSentinel = []byte("==OPENFLUX-BENCH-END==_padding_0123456789")
+
+const benchPktSize = 1300
+
+func mbps(nBytes, ns int64) float64 {
+	if ns <= 0 {
+		return 0
+	}
+	return (float64(nBytes) / 1e6) / (float64(ns) / 1e9)
+}
+
+func ratio(a, b int64) float64 {
+	if b <= 0 {
+		return 0
+	}
+	return float64(a) / float64(b)
+}
+
+// runBenchSink receives packets and measures delivered goodput plus the
+// channel-message count (which exposes the batching factor).
+func runBenchSink(trans transport.Transport) {
+	var got, pkts, startNs int64
+	done := make(chan int64, 1)
+
+	trans.Receive(func(p []byte) {
+		if bytes.Equal(p, benchSentinel) {
+			s := atomic.LoadInt64(&startNs)
+			if s == 0 {
+				s = time.Now().UnixNano()
+			}
+			select {
+			case done <- time.Now().UnixNano() - s:
+			default:
+			}
+			return
+		}
+		if atomic.CompareAndSwapInt64(&startNs, 0, time.Now().UnixNano()) {
+			log.Printf("[BENCH-SINK] first packet received, timing started")
+		}
+		atomic.AddInt64(&got, int64(len(p)))
+		atomic.AddInt64(&pkts, 1)
+	})
+
+	if err := trans.Start(); err != nil {
+		log.Fatalf("[BENCH-SINK] start: %v", err)
+	}
+	log.Printf("[BENCH-SINK] waiting for sender...")
+
+	go func() {
+		tick := time.NewTicker(2 * time.Second)
+		defer tick.Stop()
+		for range tick.C {
+			s := atomic.LoadInt64(&startNs)
+			if s == 0 {
+				continue
+			}
+			el := time.Now().UnixNano() - s
+			g := atomic.LoadInt64(&got)
+			st := trans.Stats()
+			log.Printf("[BENCH-SINK] %.2f MB, %.3f MB/s | tunnel pkts=%d | channel msgs=%d (%.1f pkts/msg)",
+				float64(g)/1e6, mbps(g, el), atomic.LoadInt64(&pkts),
+				st.PacketsRecv, ratio(atomic.LoadInt64(&pkts), int64(st.PacketsRecv)))
+		}
+	}()
+
+	el := <-done
+	g := atomic.LoadInt64(&got)
+	st := trans.Stats()
+	log.Printf("==========================================================")
+	log.Printf("[BENCH-SINK] DONE")
+	log.Printf("  delivered    : %.2f MB", float64(g)/1e6)
+	log.Printf("  elapsed      : %.2f s", float64(el)/1e9)
+	log.Printf("  GOODPUT      : %.3f MB/s (%.0f KB/s)", mbps(g, el), mbps(g, el)*1000)
+	log.Printf("  tunnel pkts  : %d", atomic.LoadInt64(&pkts))
+	log.Printf("  channel msgs : %d", st.PacketsRecv)
+	log.Printf("  batching     : %.1f tunnel pkts per channel msg", ratio(atomic.LoadInt64(&pkts), int64(st.PacketsRecv)))
+	log.Printf("  channel bytes: %.2f MB (pre-base64, on-wire is ~1.33x)", float64(st.BytesReceived)/1e6)
+	log.Printf("==========================================================")
+}
+
+// runBenchSend pushes mb megabytes through the transport as ~MTU-sized packets,
+// honoring queue backpressure, then reports the channel-message count.
+func runBenchSend(trans transport.Transport, mb int, compressible bool) {
+	if err := trans.Start(); err != nil {
+		log.Fatalf("[BENCH-SEND] start: %v", err)
+	}
+	log.Printf("[BENCH-SEND] connecting...")
+	for i := 0; i < 600 && !trans.IsConnected(); i++ {
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !trans.IsConnected() {
+		log.Fatalf("[BENCH-SEND] transport not connected after 60s")
+	}
+	log.Printf("[BENCH-SEND] connected; pushing %d MB (compressible=%v)", mb, compressible)
+
+	total := int64(mb) * 1024 * 1024
+	payload := make([]byte, benchPktSize)
+	if compressible {
+		for i := range payload {
+			payload[i] = byte('A' + (i % 16))
+		}
+	}
+
+	var sent int64
+	start := time.Now()
+	for sent < total {
+		if compressible {
+			payload[0] = byte(sent)
+			payload[1] = byte(sent >> 8)
+		} else {
+			mrand.Read(payload)
+		}
+		for trans.Send(payload) != nil {
+			time.Sleep(time.Millisecond) // queue full: natural backpressure
+		}
+		sent += benchPktSize
+	}
+	for trans.Send(benchSentinel) != nil {
+		time.Sleep(time.Millisecond)
+	}
+
+	el := time.Since(start)
+	st := trans.Stats()
+	tunnelPkts := sent / benchPktSize
+	log.Printf("[BENCH-SEND] enqueued %.2f MB in %.2fs", float64(sent)/1e6, el.Seconds())
+	log.Printf("[BENCH-SEND] channel msgs=%d, %.1f tunnel pkts/msg, channel bytes=%.2f MB",
+		st.PacketsSent, ratio(tunnelPkts, int64(st.PacketsSent)), float64(st.BytesSent)/1e6)
+	log.Printf("[BENCH-SEND] draining to channel...")
+	time.Sleep(3 * time.Second)
+	st = trans.Stats()
+	log.Printf("[BENCH-SEND] after drain: channel msgs=%d channel bytes=%.2f MB", st.PacketsSent, float64(st.BytesSent)/1e6)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,15 +9,16 @@ require gvisor.dev/gvisor v0.0.0-20260530041128-23ef90c42be7
 require (
 	github.com/google/btree v1.1.2 // indirect
 	golang.org/x/exp v0.0.0-20250711185948-6ae5c78190dc // indirect
-	golang.org/x/sys v0.45.0
+	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 )
 
 require (
-	github.com/gopacket/gopacket v1.7.1
+	github.com/klauspost/compress v1.20.0
 	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/pion/webrtc/v3 v3.3.6
 	github.com/wlynxg/anet v0.0.5
+	github.com/xjasonlyu/windivert-go v0.0.0-20201010013527-4239d0afa76f
 	golang.org/x/crypto v0.51.0
 )
 
@@ -41,7 +42,6 @@ require (
 	github.com/pion/turn/v2 v2.1.6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
-	github.com/xjasonlyu/windivert-go v0.0.0-20201010013527-4239d0afa76f // indirect
 	golang.org/x/net v0.55.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,10 +7,10 @@ github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl76
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gopacket/gopacket v1.7.1 h1:1C7/wrJ5HyiEAYDtStJHQk4rV0ChpanZDV9+3Ov3gaM=
-github.com/gopacket/gopacket v1.7.1/go.mod h1:QKowPlTLrQU2rqV5C5I14Aoaid3l8da3kbddibc/Wgk=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/klauspost/compress v1.20.0 h1:a3C1ke2ohxFymNlb2HWAHjDeKCI90scRskErZkR0ezA=
+github.com/klauspost/compress v1.20.0/go.mod h1:LUdAzn7YLVvxLpc7y3V1m40wESHTgc1422pwwBSKYuI=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/main.go
+++ b/main.go
@@ -40,6 +40,10 @@ func main() {
 	encryptionKeyFile := flag.String("encryption-key-file", "",
 		"Optional: encrypt the transport with AES-256-GCM using a shared secret read from this file. "+
 			"Both peers must use the same secret; unset means unencrypted, unchanged behavior")
+	legacy := flag.Bool("legacy", false, "Use legacy per-packet LZ4 codec without batching (for A/B comparison)")
+	benchSend := flag.Int("bench-send", 0, "Benchmark: push this many MB through the transport, then report and exit")
+	benchSink := flag.Bool("bench-sink", false, "Benchmark: receive from the transport and measure goodput")
+	benchCompressible := flag.Bool("bench-compressible", false, "Benchmark: use compressible payload instead of random")
 	flag.Parse()
 
 	if localIP != "" {
@@ -52,7 +56,8 @@ func main() {
 		godebug.SetGCPercent(20)
 	}
 
-	if !*exitNode && !*client {
+	benchMode := *benchSink || *benchSend > 0
+	if !*exitNode && !*client && !benchMode {
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -66,8 +71,8 @@ func main() {
 	log.Printf("Transport: %s", *transportType)
 
 	config := transport.DefaultConfig()
-	var inner transport.Transport
 
+	var inner transport.Transport
 	switch *transportType {
 	case "vyandex":
 		inner = yandex.NewYandexVolgaTransport(globalDocUrl, config)
@@ -80,6 +85,9 @@ func main() {
 		log.Fatalf("Unknown transport type: %s", *transportType)
 	}
 
+	// Optional AES-256-GCM encryption sits closest to the raw transport, so on
+	// send we batch/compress first and encrypt the result (ciphertext would not
+	// compress). Both peers must use the same secret.
 	if *encryptionKeyFile != "" {
 		secretBytes, err := os.ReadFile(*encryptionKeyFile)
 		if err != nil {
@@ -100,7 +108,28 @@ func main() {
 		log.Printf("Transport encryption: AES-256-GCM enabled")
 	}
 
-	trans := transport.NewCompressedTransport(inner)
+	// App-layer codec, outermost. Default is the new batching+zstd layer;
+	// --legacy selects the old per-packet LZ4 path so the two can be compared
+	// over the same channel. Client and exit node must use the same one.
+	var trans transport.Transport
+	if *legacy {
+		log.Printf("Codec: legacy (per-packet LZ4, no batching)")
+		trans = transport.NewCompressedTransport(inner)
+	} else {
+		log.Printf("Codec: batched (zstd + coalescing)")
+		trans = transport.NewBatchedTransport(inner)
+	}
+
+	// Benchmark modes run the transport directly with no tunnel / raw socket,
+	// so they never touch the host network.
+	if *benchSink {
+		runBenchSink(trans)
+		return
+	}
+	if *benchSend > 0 {
+		runBenchSend(trans, *benchSend, *benchCompressible)
+		return
+	}
 
 	if err := trans.Start(); err != nil {
 		log.Fatalf("Failed to start transport: %v", err)

--- a/transport/batched.go
+++ b/transport/batched.go
@@ -1,0 +1,165 @@
+package transport
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"universal-bypass-tool/utils"
+)
+
+// Defaults for the coalescing layer. Tunable at runtime via env vars so the
+// batch size can be matched to the channel's per-message limits without a
+// rebuild (OPENFLUX_BATCH_BYTES / OPENFLUX_BATCH_COUNT / OPENFLUX_BATCH_LINGER_MS).
+const (
+	defaultMaxBatchBytes = 8192
+	defaultMaxBatchCount = 64
+	defaultLingerMs      = 5
+	batchQueueDepth      = 4096
+)
+
+// BatchedTransport replaces the old per-packet CompressedTransport. It queues
+// outgoing tunnel packets, coalesces bursts into a single framed+zstd batch per
+// inner transport message, and splits batches back into packets on receive.
+//
+// This is the symmetric layer: client and exit node must both use it (they do,
+// because main.go wraps both the same way).
+type BatchedTransport struct {
+	Transport
+
+	queue         chan []byte
+	lingerMs      int
+	maxBatchBytes int
+	maxBatchCount int
+
+	running atomic.Bool
+
+	mu     sync.RWMutex
+	userCb func([]byte)
+}
+
+func envInt(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+func NewBatchedTransport(inner Transport) *BatchedTransport {
+	return &BatchedTransport{
+		Transport:     inner,
+		queue:         make(chan []byte, batchQueueDepth),
+		lingerMs:      envInt("OPENFLUX_BATCH_LINGER_MS", defaultLingerMs),
+		maxBatchBytes: envInt("OPENFLUX_BATCH_BYTES", defaultMaxBatchBytes),
+		maxBatchCount: envInt("OPENFLUX_BATCH_COUNT", defaultMaxBatchCount),
+	}
+}
+
+func (b *BatchedTransport) Start() error {
+	if err := b.Transport.Start(); err != nil {
+		return err
+	}
+	b.running.Store(true)
+	go b.flushLoop()
+	return nil
+}
+
+func (b *BatchedTransport) Stop() error {
+	b.running.Store(false)
+	return b.Transport.Stop()
+}
+
+// Send copies the packet (the caller's buffer is reused by gVisor) and enqueues
+// it for batching. A full queue drops the packet; the tunnel's TCP will
+// retransmit, same as the old "write queue full" behavior.
+func (b *BatchedTransport) Send(data []byte) error {
+	p := make([]byte, len(data))
+	copy(p, data)
+	select {
+	case b.queue <- p:
+		return nil
+	default:
+		return fmt.Errorf("batch queue full")
+	}
+}
+
+func (b *BatchedTransport) Receive(callback func([]byte)) {
+	b.mu.Lock()
+	b.userCb = callback
+	b.mu.Unlock()
+
+	b.Transport.Receive(func(data []byte) {
+		pkts, err := decodeBatch(data)
+		if err != nil {
+			utils.Debugf("[BATCH] decode error (%d bytes): %v", len(data), err)
+			return
+		}
+		b.mu.RLock()
+		cb := b.userCb
+		b.mu.RUnlock()
+		if cb == nil {
+			return
+		}
+		for _, p := range pkts {
+			cb(p)
+		}
+	})
+}
+
+func (b *BatchedTransport) flushLoop() {
+	for b.running.Load() {
+		first, ok := <-b.queue
+		if !ok {
+			return
+		}
+		batch := [][]byte{first}
+		size := 2 + len(first)
+
+		// Phase 1: absorb everything already queued (burst coalescing). This
+		// alone collapses a window's worth of segments into one message.
+	drainNow:
+		for size < b.maxBatchBytes && len(batch) < b.maxBatchCount {
+			select {
+			case p, ok := <-b.queue:
+				if !ok {
+					b.Transport.Send(encodeBatch(batch))
+					return
+				}
+				batch = append(batch, p)
+				size += 2 + len(p)
+			default:
+				break drainNow
+			}
+		}
+
+		// Phase 2: brief linger to catch stragglers arriving just after the
+		// burst. Negligible next to the channel RTT, but it fills batches
+		// during steady bulk transfer.
+		if b.lingerMs > 0 && size < b.maxBatchBytes && len(batch) < b.maxBatchCount {
+			timer := time.NewTimer(time.Duration(b.lingerMs) * time.Millisecond)
+		linger:
+			for size < b.maxBatchBytes && len(batch) < b.maxBatchCount {
+				select {
+				case p, ok := <-b.queue:
+					if !ok {
+						timer.Stop()
+						b.Transport.Send(encodeBatch(batch))
+						return
+					}
+					batch = append(batch, p)
+					size += 2 + len(p)
+				case <-timer.C:
+					break linger
+				}
+			}
+			timer.Stop()
+		}
+
+		b.Transport.Send(encodeBatch(batch))
+	}
+}

--- a/transport/batched_test.go
+++ b/transport/batched_test.go
@@ -1,0 +1,125 @@
+package transport
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeTransport is a minimal in-process Transport used to test the batching
+// wrapper. With loopback=true it immediately delivers whatever is Sent back to
+// the registered receive callback (a perfect, ordered channel).
+type fakeTransport struct {
+	mu       sync.Mutex
+	sent     [][]byte
+	cb       func([]byte)
+	loopback bool
+}
+
+func (f *fakeTransport) Start() error { return nil }
+func (f *fakeTransport) Stop() error  { return nil }
+func (f *fakeTransport) Send(data []byte) error {
+	cp := append([]byte(nil), data...)
+	f.mu.Lock()
+	f.sent = append(f.sent, cp)
+	cb := f.cb
+	lb := f.loopback
+	f.mu.Unlock()
+	if lb && cb != nil {
+		cb(cp)
+	}
+	return nil
+}
+func (f *fakeTransport) Receive(cb func([]byte)) {
+	f.mu.Lock()
+	f.cb = cb
+	f.mu.Unlock()
+}
+func (f *fakeTransport) IsConnected() bool    { return true }
+func (f *fakeTransport) Stats() TransportStats { return TransportStats{} }
+
+func (f *fakeTransport) sendCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.sent)
+}
+
+func (f *fakeTransport) firstSent() []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sent) == 0 {
+		return nil
+	}
+	return f.sent[0]
+}
+
+func TestBatchedTransportRoundTripPreservesPacketsAndOrder(t *testing.T) {
+	inner := &fakeTransport{loopback: true}
+	bt := NewBatchedTransport(inner)
+	bt.lingerMs = 10
+
+	var mu sync.Mutex
+	var got [][]byte
+	bt.Receive(func(p []byte) {
+		mu.Lock()
+		got = append(got, append([]byte(nil), p...))
+		mu.Unlock()
+	})
+	if err := bt.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer bt.Stop()
+
+	want := [][]byte{[]byte("alpha"), []byte("bravo"), []byte("charlie"), {0xff, 0x00, 0x10}}
+	for _, p := range want {
+		if err := bt.Send(p); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != len(want) {
+		t.Fatalf("received %d packets, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if !bytes.Equal(got[i], want[i]) {
+			t.Fatalf("packet %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+// The core optimization: a burst of packets must collapse into ONE inner
+// transport message instead of one message per packet.
+func TestBatchedTransportCoalescesBurstIntoOneMessage(t *testing.T) {
+	inner := &fakeTransport{}
+	bt := NewBatchedTransport(inner)
+	bt.lingerMs = 50
+	if err := bt.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer bt.Stop()
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		if err := bt.Send([]byte{byte(i), 0xAA, 0xBB}); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	if c := inner.sendCount(); c != 1 {
+		t.Fatalf("expected 1 coalesced inner message, got %d", c)
+	}
+	pkts, err := decodeBatch(inner.firstSent())
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(pkts) != n {
+		t.Fatalf("expected %d packets in the batch, got %d", n, len(pkts))
+	}
+}

--- a/transport/efficiency_test.go
+++ b/transport/efficiency_test.go
@@ -1,0 +1,113 @@
+package transport
+
+import (
+	"encoding/base64"
+	"math/rand"
+	"testing"
+)
+
+// The fixed envelope the Yandex transport wraps every channel message in:
+//   42["message",{"type":"cursor","cursor":"18;<base64>"}]
+const yandexEnvelope = len(`42["message",{"type":"cursor","cursor":"18;`) + len(`"}]`)
+
+func b64len(n int) int { return base64.StdEncoding.EncodedLen(n) }
+
+// mkPkt builds a realistic IPv4+TCP packet: constant 4-tuple (one flow),
+// advancing seq/ack, optional payload. Headers repeat across a flow, which is
+// exactly what batch compression exploits.
+func mkPkt(seq, ack uint32, payload []byte) []byte {
+	p := make([]byte, 40+len(payload))
+	p[0] = 0x45
+	total := 40 + len(payload)
+	p[2], p[3] = byte(total>>8), byte(total)
+	p[8], p[9] = 64, 6
+	copy(p[12:16], []byte{10, 10, 10, 2})
+	copy(p[16:20], []byte{93, 184, 216, 34})
+	copy(p[20:22], []byte{0xab, 0xcd})
+	copy(p[22:24], []byte{0x01, 0xbb})
+	p[24], p[25], p[26], p[27] = byte(seq>>24), byte(seq>>16), byte(seq>>8), byte(seq)
+	p[28], p[29], p[30], p[31] = byte(ack>>24), byte(ack>>16), byte(ack>>8), byte(ack)
+	p[32] = 0x50
+	p[33] = 0x10
+	copy(p[34:36], []byte{0xff, 0xff})
+	copy(p[40:], payload)
+	return p
+}
+
+// legacyWire: old path — each packet compressed alone, base64'd, one message.
+func legacyWire(trace [][]byte) (bytes, msgs int) {
+	for _, pkt := range trace {
+		c := compress(pkt)
+		bytes += yandexEnvelope + b64len(len(c))
+		msgs++
+	}
+	return
+}
+
+// batchedWire: new path — coalesce into batches (same caps as BatchedTransport),
+// encode+compress the batch, base64, one message per batch.
+func batchedWire(trace [][]byte) (bytes, msgs int) {
+	i := 0
+	for i < len(trace) {
+		batch := [][]byte{trace[i]}
+		size := 2 + len(trace[i])
+		i++
+		for i < len(trace) && size < defaultMaxBatchBytes && len(batch) < defaultMaxBatchCount {
+			size += 2 + len(trace[i])
+			batch = append(batch, trace[i])
+			i++
+		}
+		w := encodeBatch(batch)
+		bytes += yandexEnvelope + b64len(len(w))
+		msgs++
+	}
+	return
+}
+
+func reportEfficiency(t *testing.T, name string, trace [][]byte) (msgGain, byteGain float64) {
+	t.Helper()
+	ob, om := legacyWire(trace)
+	nb, nm := batchedWire(trace)
+	msgGain = float64(om) / float64(nm)
+	byteGain = float64(ob) / float64(nb)
+	t.Logf("%s (%d tunnel packets)", name, len(trace))
+	t.Logf("   legacy : %6d channel msgs, %9d wire bytes", om, ob)
+	t.Logf("   batched: %6d channel msgs, %9d wire bytes", nm, nb)
+	t.Logf("   gain   : %.1fx fewer messages, %.2fx fewer wire bytes", msgGain, byteGain)
+	return
+}
+
+func TestWireEfficiencyBulkDownload(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	var trace [][]byte
+	var seq uint32 = 1000
+	for i := 0; i < 1000; i++ {
+		payload := make([]byte, 1460) // encrypted app data => incompressible
+		rng.Read(payload)
+		trace = append(trace, mkPkt(seq, 5000, payload))
+		seq += 1460
+	}
+	msgGain, byteGain := reportEfficiency(t, "BULK DOWNLOAD (1460B encrypted segments)", trace)
+	if msgGain < 3 {
+		t.Errorf("expected >=3x fewer messages on bulk, got %.1fx", msgGain)
+	}
+	if byteGain < 1.0 {
+		t.Errorf("batched should not inflate bulk wire bytes, got %.2fx", byteGain)
+	}
+}
+
+func TestWireEfficiencyAckHeavy(t *testing.T) {
+	var trace [][]byte
+	var ack uint32 = 1000
+	for i := 0; i < 1000; i++ {
+		trace = append(trace, mkPkt(42, ack, nil)) // pure 40-byte ACKs
+		ack += 1460
+	}
+	msgGain, byteGain := reportEfficiency(t, "ACK-HEAVY / INTERACTIVE (40B headers)", trace)
+	if msgGain < 20 {
+		t.Errorf("expected >=20x fewer messages on ACK flood, got %.1fx", msgGain)
+	}
+	if byteGain < 5 {
+		t.Errorf("expected >=5x fewer wire bytes on ACK flood, got %.2fx", byteGain)
+	}
+}

--- a/transport/framing.go
+++ b/transport/framing.go
@@ -1,0 +1,120 @@
+package transport
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// Wire format for a batched frame (one Yandex/transport message can now carry
+// many tunnel packets):
+//
+//	[0]   version byte (batchFormatVersion)
+//	[1]   flags (bit0 = payload is zstd-compressed)
+//	[2:]  payload: a sequence of [2-byte big-endian length][packet] records,
+//	      optionally zstd-compressed as a whole.
+const (
+	batchFormatVersion = 0x02
+	batchFlagZstd      = 0x01
+)
+
+var (
+	zstdEnc *zstd.Encoder
+	zstdDec *zstd.Decoder
+)
+
+func init() {
+	var err error
+	// SpeedDefault (~level 3): far better ratio than LZ4 at a CPU cost that is
+	// irrelevant next to the Yandex channel's latency. Single-shot EncodeAll /
+	// DecodeAll are safe for concurrent use on a shared instance.
+	zstdEnc, err = zstd.NewWriter(nil,
+		zstd.WithEncoderLevel(zstd.SpeedDefault),
+		zstd.WithEncoderConcurrency(1),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("zstd encoder init: %v", err))
+	}
+	zstdDec, err = zstd.NewReader(nil,
+		zstd.WithDecoderConcurrency(1),
+		// Bound the damage from a malformed/hostile frame injected into the
+		// shared document: cap decompressed memory.
+		zstd.WithDecoderMaxMemory(8<<20),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("zstd decoder init: %v", err))
+	}
+}
+
+// frameBatch concatenates packets into length-prefixed records.
+func frameBatch(pkts [][]byte) []byte {
+	total := 0
+	for _, p := range pkts {
+		total += 2 + len(p)
+	}
+	out := make([]byte, 0, total)
+	var lenbuf [2]byte
+	for _, p := range pkts {
+		binary.BigEndian.PutUint16(lenbuf[:], uint16(len(p)))
+		out = append(out, lenbuf[:]...)
+		out = append(out, p...)
+	}
+	return out
+}
+
+// encodeBatch serializes packets into a single wire frame, compressing the
+// whole batch with zstd only when that actually shrinks it.
+func encodeBatch(pkts [][]byte) []byte {
+	framed := frameBatch(pkts)
+	compressed := zstdEnc.EncodeAll(framed, nil)
+
+	if len(compressed) < len(framed) {
+		out := make([]byte, 2, 2+len(compressed))
+		out[0] = batchFormatVersion
+		out[1] = batchFlagZstd
+		return append(out, compressed...)
+	}
+	out := make([]byte, 2, 2+len(framed))
+	out[0] = batchFormatVersion
+	out[1] = 0
+	return append(out, framed...)
+}
+
+// decodeBatch reverses encodeBatch, returning the original packets.
+func decodeBatch(data []byte) ([][]byte, error) {
+	if len(data) < 2 {
+		return nil, fmt.Errorf("batch frame too short: %d bytes", len(data))
+	}
+	if data[0] != batchFormatVersion {
+		return nil, fmt.Errorf("unknown batch version 0x%02x", data[0])
+	}
+	flags := data[1]
+	payload := data[2:]
+
+	framed := payload
+	if flags&batchFlagZstd != 0 {
+		var err error
+		framed, err = zstdDec.DecodeAll(payload, nil)
+		if err != nil {
+			return nil, fmt.Errorf("zstd decode: %w", err)
+		}
+	}
+
+	var pkts [][]byte
+	for len(framed) > 0 {
+		if len(framed) < 2 {
+			return nil, fmt.Errorf("truncated length prefix")
+		}
+		n := int(binary.BigEndian.Uint16(framed[:2]))
+		framed = framed[2:]
+		if len(framed) < n {
+			return nil, fmt.Errorf("truncated packet: need %d, have %d", n, len(framed))
+		}
+		pkt := make([]byte, n)
+		copy(pkt, framed[:n])
+		pkts = append(pkts, pkt)
+		framed = framed[n:]
+	}
+	return pkts, nil
+}

--- a/transport/framing_test.go
+++ b/transport/framing_test.go
@@ -1,0 +1,110 @@
+package transport
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+)
+
+// round-trips a set of packets through encode/decode and asserts equality.
+func assertBatchRoundTrip(t *testing.T, pkts [][]byte) {
+	t.Helper()
+	wire := encodeBatch(pkts)
+	got, err := decodeBatch(wire)
+	if err != nil {
+		t.Fatalf("decodeBatch error: %v", err)
+	}
+	if len(got) != len(pkts) {
+		t.Fatalf("packet count = %d, want %d", len(got), len(pkts))
+	}
+	for i := range pkts {
+		if !bytes.Equal(got[i], pkts[i]) {
+			t.Fatalf("packet %d mismatch:\n got=%v\nwant=%v", i, got[i], pkts[i])
+		}
+	}
+}
+
+func TestBatchRoundTripSinglePacket(t *testing.T) {
+	assertBatchRoundTrip(t, [][]byte{[]byte("hello world")})
+}
+
+func TestBatchRoundTripManyPackets(t *testing.T) {
+	pkts := [][]byte{
+		[]byte("first"),
+		{0x00, 0x01, 0x02, 0xfe, 0xff},
+		[]byte("a much longer third packet with some repetition repetition repetition"),
+		{},
+		[]byte("last"),
+	}
+	assertBatchRoundTrip(t, pkts)
+}
+
+func TestBatchRoundTripBinaryMTUSized(t *testing.T) {
+	// Realistic full-MTU TCP payloads with arbitrary binary content.
+	mk := func(fill byte) []byte {
+		b := make([]byte, 1460)
+		for i := range b {
+			b[i] = fill ^ byte(i)
+		}
+		return b
+	}
+	assertBatchRoundTrip(t, [][]byte{mk(0x11), mk(0x22), mk(0x33)})
+}
+
+func TestBatchRoundTripEmptyList(t *testing.T) {
+	got, err := decodeBatch(encodeBatch(nil))
+	if err != nil {
+		t.Fatalf("decodeBatch error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 packets, got %d", len(got))
+	}
+}
+
+// A compressible batch must actually use the compressed path and shrink,
+// proving zstd is wired in (not just a raw passthrough).
+func TestBatchCompressesRepetitiveData(t *testing.T) {
+	pkt := bytes.Repeat([]byte("ABCDEFGH"), 512) // 4096 bytes, highly compressible
+	pkts := [][]byte{pkt, pkt, pkt}
+	wire := encodeBatch(pkts)
+
+	rawFramedLen := 0
+	for _, p := range pkts {
+		rawFramedLen += 2 + len(p)
+	}
+	if len(wire) >= rawFramedLen {
+		t.Fatalf("expected compression to shrink %d framed bytes, got wire len %d", rawFramedLen, len(wire))
+	}
+	assertBatchRoundTrip(t, pkts)
+}
+
+// Incompressible data must fall back to the uncompressed path and still
+// round-trip (zstd would otherwise inflate it).
+func TestBatchIncompressibleFallsBackAndRoundTrips(t *testing.T) {
+	pkt := make([]byte, 1200)
+	if _, err := rand.Read(pkt); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	assertBatchRoundTrip(t, [][]byte{pkt})
+}
+
+func TestDecodeBatchRejectsUnknownVersion(t *testing.T) {
+	if _, err := decodeBatch([]byte{0xFF, 0x00}); err == nil {
+		t.Fatal("expected error for unknown version byte")
+	}
+}
+
+func TestDecodeBatchRejectsTruncatedLengthPrefix(t *testing.T) {
+	// valid header, flags=0 (uncompressed), then a length prefix claiming 10
+	// bytes but only 2 present.
+	bad := []byte{batchFormatVersion, 0x00, 0x00, 0x0A, 0x01, 0x02}
+	if _, err := decodeBatch(bad); err == nil {
+		t.Fatal("expected error for truncated length-prefixed packet")
+	}
+}
+
+func TestDecodeBatchRejectsShortFrame(t *testing.T) {
+	if _, err := decodeBatch([]byte{batchFormatVersion}); err == nil {
+		t.Fatal("expected error for frame shorter than header")
+	}
+}

--- a/transport/yandex/yandex.go
+++ b/transport/yandex/yandex.go
@@ -20,6 +20,14 @@ import (
 	"universal-bypass-tool/utils"
 )
 
+// Precompiled once. cursorPayloadRe in particular runs on every inbound
+// message, so compiling it per call (as before) was pure overhead on the hot
+// receive path.
+var (
+	cursorPayloadRe = regexp.MustCompile(`"cursor":"[^;]+;([^"]+)"`)
+	clientConfigRe  = regexp.MustCompile(`<script[^>]*id="client-config"[^>]*>(.*?)</script>`)
+)
+
 type YandexDocsInfo struct {
 	CookieStr   string
 	Token       string
@@ -217,27 +225,52 @@ func (t *YandexDocsTransport) connectToDoc(attempt int) {
 }
 
 func (t *YandexDocsTransport) writerLoop() {
-	for t.IsRunning() {
+	// The write queue is created once and preserved across reconnects, so we
+	// capture it and block on it instead of polling with a 10ms sleep. The old
+	// poll added up to 10ms of latency to every send and woke the CPU 100x/sec
+	// while idle.
+	var queue chan []byte
+	for t.IsRunning() && queue == nil {
 		t.Mu.Lock()
-		session := t.session
+		if t.session != nil {
+			queue = t.session.WriteQueue
+		}
 		t.Mu.Unlock()
+		if queue == nil {
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	if queue == nil {
+		return
+	}
 
+	var pending []byte
+	for t.IsRunning() {
+		if pending == nil {
+			packet, ok := <-queue
+			if !ok {
+				return
+			}
+			pending = packet
+		}
+
+		t.Mu.RLock()
+		session := t.session
+		t.Mu.RUnlock()
 		if session == nil || session.Conn == nil {
-			time.Sleep(10 * time.Millisecond)
+			// Mid-reconnect: hold the packet and retry rather than drop it.
+			time.Sleep(15 * time.Millisecond)
 			continue
 		}
 
-		select {
-		case packet := <-session.WriteQueue:
-			payload := base64.StdEncoding.EncodeToString(packet)
-			msg := fmt.Sprintf(`42["message",{"type":"cursor","cursor":"18;%s"}]`, payload)
-
-			if err := session.safeWrite(websocket.TextMessage, []byte(msg)); err != nil {
-				utils.Debugf("[YDOCS] Write error: %v", err)
-			}
-		default:
-			time.Sleep(10 * time.Millisecond)
+		payload := base64.StdEncoding.EncodeToString(pending)
+		msg := fmt.Sprintf(`42["message",{"type":"cursor","cursor":"18;%s"}]`, payload)
+		if err := session.safeWrite(websocket.TextMessage, []byte(msg)); err != nil {
+			utils.Debugf("[YDOCS] Write error: %v", err)
+			time.Sleep(15 * time.Millisecond)
+			continue // keep pending; the reconnect will bring up a new conn
 		}
+		pending = nil
 	}
 }
 
@@ -310,8 +343,7 @@ func (t *YandexDocsTransport) extractBase64String(response string) string {
 		return response[left : left+right]
 	}
 
-	re := regexp.MustCompile(`"cursor":"[^;]+;([^"]+)"`)
-	matches := re.FindStringSubmatch(response)
+	matches := cursorPayloadRe.FindStringSubmatch(response)
 	if len(matches) > 1 {
 		return matches[1]
 	}
@@ -386,8 +418,7 @@ func (t *YandexDocsTransport) fetchDocInfo(url, userID string) (YandexDocsInfo, 
 		cookies = append(cookies, fmt.Sprintf("%s=%s", c.Name, c.Value))
 	}
 
-	re := regexp.MustCompile(`<script[^>]*id="client-config"[^>]*>(.*?)</script>`)
-	matches := re.FindStringSubmatch(html)
+	matches := clientConfigRe.FindStringSubmatch(html)
 	if len(matches) < 2 {
 		// Help diagnose: is this a login page, a new-editor page, etc.?
 		hint := "no client-config script"


### PR DESCRIPTION
## Зачем

Узкое место — не CPU, а сам канал Yandex.Docs. Каждое сообщение — это одно курсор-обновление в веб-сокете с base64 и JSON-обёрткой. Сейчас на **каждый** IP-пакет туннеля уходит отдельное такое сообщение. На потоке и особенно на мелких пакетах (ACK-и) это даёт тучу сообщений и фиксированные накладные расходы на каждое.

Плюс три мелких тормоза по дороге:
- `writerLoop` опрашивал очередь с `time.Sleep(10ms)` — до 10 мс задержки на каждую отправку и холостые пробуждения CPU.
- `regexp.MustCompile` компилировался заново на **каждое** входящее сообщение (горячий путь приёма).
- LZ4 сжимал каждый пакет по отдельности — маленькое окно, толку мало.

## Что поменял (простыми словами)

1. **Батчинг** — новый слой `BatchedTransport` (`transport/batched.go`, `transport/framing.go`). Копит исходящие пакеты и склеивает всплеск в **одно** сообщение канала. Формат кадра намеренно простой:

   ```
   [1 байт версии = 0x02][1 байт флагов][пакеты: на каждый 2 байта длины + данные]
   ```

   Вся пачка сжимается zstd (если сжатие не помогло — шлём как есть, флаг = 0). На приёме кадр разбирается обратно на исходные пакеты. Клиент и нода используют этот слой одинаково — симметрично.
2. **`writerLoop`** (`transport/yandex/yandex.go`) — вместо опроса со `sleep` блокирующе читает очередь; при реконнекте держит текущий пакет, а не теряет его.
3. **Регэкспы** вынес в пакетные переменные — компилируются один раз, а не на каждое сообщение.
4. **zstd вместо LZ4** — лучше жмёт повторяющиеся заголовки IP/TCP внутри пачки. На зашифрованном payload выигрыша по сжатию почти нет (ни там, ни там), поэтому главный выигрыш даёт именно батчинг, а не смена кодека.
5. **Флаги**: `--legacy` — старый кодек (для сравнения и совместимости), `--bench-send N` / `--bench-sink` — замер скорости прямо по транспорту, без туннеля и raw-сокета.

## Результаты

Офлайн-замер на реальных размерах (кодек + base64 + обёртка), `go test ./transport/ -run TestWireEfficiency -v`:

| Трафик | Сообщений канала | Байт на проводе |
|---|---|---|
| Массовая загрузка (шифр. сегменты 1460Б) | **6.0× меньше** | ≈ столько же (доминирует base64) |
| ACK-трафик (заголовки 40Б) | **62× меньше** | **18× меньше** |

Живой прогон через Яндекс: новая версия ~**6 МБ/с**, **7 пакетов туннеля в одном сообщении** канала.

Как проверял: `go test ./...` (round-trip кодека, коалесинг «пачка → одно сообщение», отказ на битых кадрах, сравнение эффективности) + живой бенч `--bench-send`/`--bench-sink` через реальный документ Яндекса.

## Совместимость — важно

Новый формат кадра **несовместим** со старым LZ4-форматом: новый клиент не договорится со старой нодой и наоборот. Обе стороны нужно обновлять вместе. `--legacy` полностью сохраняет старое поведение. Я сделал батчинг поведением по умолчанию и оставил переключатель — если удобнее, можно спрятать за флаг или поднять мажорную версию, на твоё усмотрение.

## Зависимость

`github.com/klauspost/compress` (zstd) — чистый Go, без cgo, собирается под все платформы, включая Android/iOS (проверял сборку под arm64/arm/386/darwin-arm64/windows-arm64).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
