### PR TITLE
exit-node: fix RST/EPERM spam and yandex transport handshake race

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -55,7 +55,14 @@ case "${DEBUG:-0}" in
 esac
 
 if [ "$role" = exit-node ]; then
-  echo "[entrypoint] dropping outbound TCP RSTs inside the container netns"
+  echo "[entrypoint] dropping outbound TCP RSTs inside the container netns (except our own, fwmark 100)"
+  # The mark-100 RETURN rule must come first: it exempts RSTs the exit node's
+  # own raw socket sends on purpose (rawSocketMark in tunnel/rawsocket_linux.go)
+  # so only the kernel's spurious auto-RSTs (no fwmark, since they're not
+  # sent through that socket) get dropped below.
+  if ! iptables -A OUTPUT -p tcp --tcp-flags RST RST -m mark --mark 100 -j RETURN; then
+    echo "[entrypoint] WARNING: iptables failed (missing NET_ADMIN?); kernel RSTs will kill tunnel connections" >&2
+  fi
   if ! iptables -A OUTPUT -p tcp --tcp-flags RST RST -j DROP; then
     echo "[entrypoint] WARNING: iptables failed (missing NET_ADMIN?); kernel RSTs will kill tunnel connections" >&2
   fi

--- a/transport/yandex/yandex.go
+++ b/transport/yandex/yandex.go
@@ -173,6 +173,26 @@ func (t *YandexDocsTransport) connectToDoc(attempt int) {
 			UserID:     userID,
 		}
 
+		connectedAt := time.Now()
+
+		// Wait for the server's engine.io OPEN packet ("0{...sid...}") before
+		// sending anything. Sending our socket.io "40"/"42" packets right
+		// after the WS upgrade (the old behavior) races the server's own
+		// handshake packet - observed empirically as the server closing with
+		// 1005 within ~50-100ms of accepting the connection, right after it
+		// emits its "0{...}" packet, because the client wrote to the
+		// namespace before the handshake it announces was actually open.
+		_, first, err := conn.ReadMessage()
+		if err != nil {
+			utils.Debugf("[YDOCS] Read error waiting for engine.io open: %v", err)
+			conn.Close()
+			t.scheduleReconnect(attempt)
+			return
+		}
+		if len(first) == 0 || first[0] != '0' {
+			utils.Debugf("[YDOCS] unexpected first message (wanted engine.io open \"0...\"): %s", string(first))
+		}
+
 		t.Mu.Lock()
 		t.session = session
 		t.SetConnected(true)
@@ -195,7 +215,6 @@ func (t *YandexDocsTransport) connectToDoc(attempt int) {
 		messagePart, _ := json.Marshal([]interface{}{"message", authData})
 		session.safeWrite(websocket.TextMessage, []byte(fmt.Sprintf("42%s", string(messagePart))))
 
-		connectedAt := time.Now()
 		for t.IsRunning() {
 			_, message, err := conn.ReadMessage()
 			if err != nil {

--- a/tunnel/rawsocket_linux.go
+++ b/tunnel/rawsocket_linux.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
@@ -17,6 +18,15 @@ import (
 	"universal-bypass-tool/network"
 	"universal-bypass-tool/utils"
 )
+
+// rawSocketMark tags every packet WritePackets sends through sendFd (SYNs,
+// data, and our own legitimate RSTs) so entrypoint.sh's OUTPUT DROP rule for
+// RST packets can exempt them by fwmark. Without this, that rule can't tell
+// our raw socket's own RSTs apart from the kernel's spurious auto-RSTs
+// (fired because this netstack's sockets have no kernel-side counterpart)
+// and drops both — which surfaces here as Sendto returning EPERM. Must match
+// the mark used in docker/entrypoint.sh.
+const rawSocketMark = 100
 
 type RawSocketEndpoint struct {
 	dispatcher      stack.NetworkDispatcher
@@ -39,6 +49,13 @@ func NewRawSocketEndpoint(nicID tcpip.NICID) (*RawSocketEndpoint, error) {
 	if err := syscall.SetsockoptInt(sendFd, syscall.IPPROTO_IP, syscall.IP_HDRINCL, 1); err != nil {
 		syscall.Close(sendFd)
 		return nil, fmt.Errorf("IP_HDRINCL: %v", err)
+	}
+
+	if err := unix.SetsockoptInt(sendFd, unix.SOL_SOCKET, unix.SO_MARK, rawSocketMark); err != nil {
+		// Non-fatal: without the mark, entrypoint.sh's RST-drop rule can't
+		// exempt our own RSTs and we're back to the original EPERM bug, but
+		// the tunnel itself still works.
+		utils.Debugf("[RAW-NIC%d] SO_MARK failed (need NET_ADMIN?): %v", nicID, err)
 	}
 
 	recvFd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_RAW, syscall.IPPROTO_TCP)


### PR DESCRIPTION
## Summary

Two correctness bugs in the exit-node path, found while running a
local exit node for a while and watching the logs closely.

**1. `[RAW-NIC2] Sendto failed: operation not permitted` spam (`tunnel/rawsocket_linux.go`, `docker/entrypoint.sh`)**

The exit node's TCP stack runs entirely in userspace (gVisor), so the
kernel has no socket for these connections and answers with its own
spurious RSTs - `entrypoint.sh`'s `OUTPUT` DROP rule exists to swallow
exactly those. But it matched *all* outbound RSTs, including the ones
`WritePackets` legitimately sends via the raw socket to close real
connections. A local netfilter DROP on a raw-socket send surfaces back
to the caller as `EPERM` instead of silently dropping - that's the
source of the repeated log line. Under real traffic this fired well
over a thousand times in 5 minutes.

Fix: mark every packet the raw socket sends with `SO_MARK=100`, and
add a `RETURN` rule ahead of the DROP rule that exempts that mark.
Only truly kernel-originated RSTs (never marked, since they don't go
through our socket) still get dropped.

Verified live: EPERM count went from ~1166/5min to 0/5min at
equivalent traffic volume; iptables counters confirm the split
(RETURN rule catching our marked RSTs, DROP rule still catching the
kernel's unmarked ones).

**2. yandex transport: handshake race causes near-instant `close 1005` (`transport/yandex/yandex.go`)**

`connectToDoc()` sent the socket.io `40{token}` connect packet and the
`42[...]` auth event immediately after the WebSocket upgrade, without
ever reading anything from the server first. The server sends its own
engine.io OPEN packet (`0{"sid":...}`) first per protocol - writing
before reading that raced it, and the server closed the connection
with `websocket: close 1005 (no status)` within ~50-100ms almost every
time. This meant a working session only ever happened by luck, when
the timing happened to land in the right order on its own.

Confirmed by temporarily logging otherwise-unhandled incoming
messages: the OPEN packet consistently arrived right before the close.

Fix: block on one `ReadMessage()` for the OPEN packet before sending
`40`/`42`. Handshakes now reliably complete (auth ack, license,
waitAuth, documentOpen all arrive in order) and real tunnel traffic
flows afterward.

## Test plan

- [x] `CGO_ENABLED=0 go build` succeeds (built via the repo's own
      Dockerfile)
- [x] Deployed as the `exit-node` compose profile against a real
      Yandex Disk share link; confirmed via `docker logs` +
      `iptables -L OUTPUT -n -v` that RSTs split correctly between the
      RETURN and DROP rules under real traffic
- [x] Confirmed the yandex transport now reaches `documentOpen` and
      carries real tunnel traffic, where before it essentially never
      did deterministically

Not touched: a separate, deeper issue where even a successful yandex
session eventually gets an explicit server-side `disconnectReason`
(code 4007, "drop") after roughly a minute - that looks like Yandex's
own collab-session participant limits, not a client bug, and is out of
scope here.