### PR TITLE
yandex: reduce reconnect churn (participant pile-up) and close stale conns

### DIFF
--- a/transport/yandex/yandex.go
+++ b/transport/yandex/yandex.go
@@ -201,6 +201,7 @@ func (t *YandexDocsTransport) connectToDoc(attempt int) {
 			if err != nil {
 				utils.Debugf("[YDOCS] Read error: %v", err)
 				t.SetConnected(false)
+				conn.Close()
 				// If the session was healthy for a while, treat the next
 				// connect as fresh (attempt -1 -> next attempt 0) so backoff
 				// doesn't keep growing across normal long-lived reconnects.
@@ -337,18 +338,26 @@ func (t *YandexDocsTransport) scheduleReconnect(attempt int) {
 	t.connectToDoc(next)
 }
 
-// reconnectBackoff returns an exponential backoff with jitter, capped at 15s.
+// reconnectBackoff returns an exponential backoff with jitter, capped at 30s.
+//
+// Each reconnect dials a brand new WebSocket, which the doc-collab server
+// registers as a brand new participant in the doc's room regardless of
+// client-side user-id reuse - a fast connect/close/reconnect loop piles up
+// visible "ghost" participants quickly (confirmed by logging the server's
+// participant-list messages during a failure streak). The floor here (was
+// 500ms) is raised to slow that churn down; this doesn't change steady-state
+// throughput since successful connects never hit backoff at all.
 func reconnectBackoff(n int) time.Duration {
 	if n < 1 {
 		n = 1
 	}
 	shift := n - 1
-	if shift > 5 {
-		shift = 5
+	if shift > 4 {
+		shift = 4
 	}
-	d := 500 * time.Millisecond * time.Duration(1<<uint(shift))
-	if d > 15*time.Second {
-		d = 15 * time.Second
+	d := 1500 * time.Millisecond * time.Duration(1<<uint(shift))
+	if d > 30*time.Second {
+		d = 30 * time.Second
 	}
 	// add up to +50% jitter
 	d += time.Duration(rand.Int63n(int64(d/2) + 1))


### PR DESCRIPTION
## Summary

Follow-up to #54 (which fixes the yandex transport's handshake race).
With that race fixed, sessions establish reliably, but I noticed
something else while watching a live exit node for a while afterward:
a session that fully succeeds still eventually gets an explicit
server-side disconnect (`disconnectReason` code 4007, `"drop"`) after
roughly 60-90 seconds.

While digging into that (not fixed here - see below), I logged the
server's `auth`/`connectState` messages, which list the doc room's
current participants. Every WebSocket reconnect - even ones that fail
fast - registers as a brand new "Anonymous" participant server-side
(Yandex assigns its own participant id per connection and ignores our
client-side `user.id`). During a failure streak I saw 2-3 simultaneous
ghost participants pile up in the same room from nothing but our own
reconnect attempts.

This PR doesn't fix the underlying `4007`/`drop` behavior (that looks
like it's coming from Yandex's own collab-session participant limits,
not something client-side code controls), but it does reduce how fast
our own retries can pile up participants:

- `reconnectBackoff()`'s floor goes from 500ms to 1.5s and its cap
  from 15s to 30s. Successful connects never hit backoff at all, so
  this only affects failure streaks.
- The main read loop's error branch now calls `conn.Close()` instead
  of leaving the socket for the runtime to clean up whenever.

## Test plan

- [x] `CGO_ENABLED=0 go build` succeeds (via the repo's Dockerfile)
- [x] Deployed as the exit-node profile; confirmed in logs that the
      new backoff floor/cap take effect on reconnect